### PR TITLE
Update cron schedule to run every Monday

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: Call fetch workflow
 on:
     workflow_dispatch:
     schedule:
-      - cron: 0 9 1 * *
+      - cron: 0 9 * * 1
 
 jobs:
   call-fetch-data:


### PR DESCRIPTION
Considering the number of sources - and events - in the Spektrix workflow, I believe it needs to run at least once per week. We might even want to consider running it every other day.